### PR TITLE
Harden batch utilities and async cache handling

### DIFF
--- a/aitrans/document.py
+++ b/aitrans/document.py
@@ -1,9 +1,10 @@
 """文档翻译模块"""
 
-import asyncio
 import logging
-import time
-from typing import List, Optional
+from itertools import chain
+from time import perf_counter
+from typing import List, Optional, Tuple
+
 from .models import AITranslated
 from .utils import BatchProcessor
 
@@ -13,30 +14,39 @@ logger = logging.getLogger(__name__)
 class DocumentTranslator:
     """文档翻译器"""
 
-    def __init__(self, translator: 'AITranslator', context_window: int = 2, batch_size: int = 5):
+    def __init__(
+        self,
+        translator: 'AITranslator',
+        context_window: int = 2,
+        batch_size: int = 5,
+        max_workers: Optional[int] = None,
+    ):
         self.translator = translator
         self.context_window = context_window
         self.batch_size = batch_size
+        perf_workers = max_workers or translator.perf_config.get(
+            'max_workers', translator.batch_processor.max_workers
+        )
         self.processor = BatchProcessor(
-            max_workers=translator.perf_config['max_workers'],
+            max_workers=int(perf_workers),
             batch_size=batch_size
         )
-        self._paragraphs = []
-        self._context_cache = {}
 
-    def _get_context(self, index: int) -> str:
-        """获取指定段落的上下文"""
-        if index in self._context_cache:
-            return self._context_cache[index]
+    def _build_contexts(self, paragraphs: List[str]) -> List[str]:
+        total = len(paragraphs)
+        contexts: List[str] = [""] * total
+        window = self.context_window
 
-        start_idx = max(0, index - self.context_window)
-        end_idx = min(len(self._paragraphs), index + self.context_window + 1)
-        context_paras = self._paragraphs[start_idx:index] + \
-            self._paragraphs[index+1:end_idx]
-        context = "\n".join(context_paras)
+        for index in range(total):
+            start_idx = max(0, index - window)
+            end_idx = min(total, index + window + 1)
+            context_iter = chain(
+                paragraphs[start_idx:index],
+                paragraphs[index + 1 : end_idx],
+            )
+            contexts[index] = "\n".join(context_iter)
 
-        self._context_cache[index] = context
-        return context
+        return contexts
 
     async def translate_document(self,
                                  paragraphs: List[str],
@@ -54,13 +64,12 @@ class DocumentTranslator:
         if not paragraphs:
             return []
 
-        self._paragraphs = paragraphs
-        self._context_cache.clear()
-        start_time = time.time()
+        contexts = self._build_contexts(paragraphs)
+        start_time = perf_counter()
 
         async def translate_paragraph(text: str, index: int) -> AITranslated:
             try:
-                context = self._get_context(index)
+                context = contexts[index]
                 return await self.translator.translate_with_context(
                     text=text,
                     context=context,
@@ -78,28 +87,20 @@ class DocumentTranslator:
                     text=f"Translation failed: {str(e)}"
                 )
 
-        try:
-            # 创建任务列表
-            tasks = []
-            for i, text in enumerate(paragraphs):
-                tasks.append(translate_paragraph(text, i))
+        async def runner(item: Tuple[int, str]) -> AITranslated:
+            index, text = item
+            return await translate_paragraph(text, index)
 
-            # 分批执行任务
-            results = []
-            for i in range(0, len(tasks), self.batch_size):
-                batch = tasks[i:i + self.batch_size]
-                batch_results = await asyncio.gather(*batch)
-                results.extend(batch_results)
+        indexed_paragraphs = list(enumerate(paragraphs))
+        results = await self.processor.process(
+            indexed_paragraphs, runner, batch_size=self.batch_size
+        )
 
-            duration = time.time() - start_time
-            success_count = sum(
-                1 for r in results if not r.text.startswith("Translation failed"))
-            logger.info(
-                f"Document translation completed in {duration:.2f}s - "
-                f"{len(paragraphs)} paragraphs, {success_count} successful"
-            )
+        duration = perf_counter() - start_time
+        success_count = sum(1 for r in results if not r.text.startswith("Translation failed"))
+        logger.info(
+            f"Document translation completed in {duration:.2f}s - "
+            f"{len(paragraphs)} paragraphs, {success_count} successful"
+        )
 
-            return results
-        finally:
-            self._context_cache.clear()
-            self._paragraphs = []
+        return results


### PR DESCRIPTION
## Summary
- keep BatchProcessor workers saturated while supporting per-call overrides and offloading synchronous callables to background threads
- offload MultiLevelCache disk I/O and cleanup work to threads to avoid blocking the event loop
- precompute document translation contexts, use perf_counter timing, and honor performance profile worker counts
- align AITranslator's batch processor workers with the active performance profile

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d49cdc0ce0832d9ba87c3ce40bef4b